### PR TITLE
s3gw container for docker

### DIFF
--- a/build/Dockerfile.build-container
+++ b/build/Dockerfile.build-container
@@ -1,0 +1,26 @@
+FROM opensuse/tumbleweed
+LABEL Name=s3gw
+
+ARG ID=s3gw
+ENV ID=$ID
+
+RUN zypper -n install libblkid1 \
+libexpat1 \ 
+libtcmalloc4 \
+libfmt8 \
+libibverbs1 \
+librdmacm1 \ 
+liboath0 \
+libicu70
+
+RUN mkdir -p /data
+
+COPY ./bin/radosgw /usr/bin/radosgw
+COPY ./lib/*.so* /usr/lib64/
+
+CMD ["/usr/bin/radosgw", "-d",\
+"--no-mon-config",\
+"--id", "${ID}",\
+"--rgw-data", "/data/",\
+"--run-dir", "/run/",\
+"--rgw-backend-store", "dbstore"]

--- a/build/Dockerfile.build-container
+++ b/build/Dockerfile.build-container
@@ -11,7 +11,7 @@ libfmt8 \
 libibverbs1 \
 librdmacm1 \ 
 liboath0 \
-libicu70
+libicu71
 
 RUN mkdir -p /data
 

--- a/build/README.md
+++ b/build/README.md
@@ -83,5 +83,5 @@ $ podman run --replace --name=s3gw -it -p 7480:7480 localhost/s3gw
 or, when using Docker:
 
 ```
-$ docker run -p 7480:7480 s3gw
+$ docker run -p 7480:7480 localhost/s3gw
 ```

--- a/build/README.md
+++ b/build/README.md
@@ -10,6 +10,10 @@ Make sure you've installed the following applications:
 - podman
 - buildah
 
+Optionally, if you prefer building an `s3gw` container image with docker you will need:
+
+- docker
+
 The build scripts expect the following directory hierarchy.
 
 ```
@@ -54,6 +58,14 @@ $ cd ~/git/s3gw-core/build
 $ ./build-container.sh
 ```
 
+By default, this will build an `s3gw` image using podman.
+In order to build an `s3gw` image with Docker, you can run:
+
+```
+$ cd ~/git/s3gw-core/build
+$ CONTAINER_ENGINE=docker ./build-container.sh
+```
+
 The container build script expects the `radosgw` binary at the relative
 path `../ceph/build/bin`. This can be customized via the `CEPH_DIR`
 environment variable.
@@ -66,4 +78,10 @@ Finally, you can run the `s3gw` container with the following command:
 
 ```
 $ podman run --replace --name=s3gw -it -p 7480:7480 localhost/s3gw
+```
+
+or, when using Docker:
+
+```
+$ docker run -p 7480:7480 s3gw
 ```

--- a/build/build-container.sh
+++ b/build/build-container.sh
@@ -6,6 +6,7 @@ BASE_IMAGE=${BASE_IMAGE:-"registry.opensuse.org/opensuse/tumbleweed:latest"}
 IMAGE_NAME=${IMAGE_NAME:-"s3gw"}
 CEPH_DIR=$(realpath ${CEPH_DIR:-"../../ceph/"})
 INSTALL_PACKAGES=${INSTALL_PACKAGES:-"libblkid1 libexpat1 libtcmalloc4 libfmt8 libibverbs1 librdmacm1 liboath0 libicu70"}
+CONTAINER_ENGINE=${CONTAINER_ENGINE:-"podman"}
 
 registry=
 registry_args=
@@ -22,6 +23,10 @@ build_container_image() {
   echo "BASE_IMAGE=${BASE_IMAGE}"
   echo "IMAGE_NAME=${IMAGE_NAME}"
   echo "CEPH_DIR=${CEPH_DIR}"
+  echo "CONTAINER_ENGINE=${CONTAINER_ENGINE}"
+
+  case ${CONTAINER_ENGINE} in
+    podman)
 
   tmpfile=$(mktemp)
   cat > ${tmpfile} << EOF
@@ -46,6 +51,11 @@ EOF
     buildah push ${registry_args} localhost/${IMAGE_NAME} \
       ${registry}/${IMAGE_NAME}
   fi
+      ;;
+    docker)
+    docker build -t ${IMAGE_NAME} -f ./Dockerfile.build-container ${CEPH_DIR}/build
+      ;;
+  esac
 }
 
 while [ $# -ge 1 ]; do

--- a/build/build-container.sh
+++ b/build/build-container.sh
@@ -5,7 +5,7 @@ set -e
 BASE_IMAGE=${BASE_IMAGE:-"registry.opensuse.org/opensuse/tumbleweed:latest"}
 IMAGE_NAME=${IMAGE_NAME:-"s3gw"}
 CEPH_DIR=$(realpath ${CEPH_DIR:-"../../ceph/"})
-INSTALL_PACKAGES=${INSTALL_PACKAGES:-"libblkid1 libexpat1 libtcmalloc4 libfmt8 libibverbs1 librdmacm1 liboath0 libicu70"}
+INSTALL_PACKAGES=${INSTALL_PACKAGES:-"libblkid1 libexpat1 libtcmalloc4 libfmt8 libibverbs1 librdmacm1 liboath0 libicu71"}
 CONTAINER_ENGINE=${CONTAINER_ENGINE:-"podman"}
 
 registry=
@@ -53,7 +53,7 @@ EOF
   fi
       ;;
     docker)
-    docker build -t ${IMAGE_NAME} -f ./Dockerfile.build-container ${CEPH_DIR}/build
+    docker build -t localhost/${IMAGE_NAME} -f ./Dockerfile.build-container ${CEPH_DIR}/build
       ;;
   esac
 }


### PR DESCRIPTION
- User can now choose to build the s3gw container with docker also.
  Regardless of what is employed - podman or docker engine - to build it, produced image will be OCI compliant. 

Fixes: aquarist-labs/s3gw#27
Signed-off-by: Giuseppe Baccini <giuseppe.baccini@suse.com>