### PR TITLE
default arguments for s3gw container

### DIFF
--- a/build/Dockerfile.build-container
+++ b/build/Dockerfile.build-container
@@ -18,9 +18,11 @@ RUN mkdir -p /data
 COPY ./bin/radosgw /usr/bin/radosgw
 COPY ./lib/*.so* /usr/lib64/
 
-CMD ["/usr/bin/radosgw", "-d",\
+ENTRYPOINT [ "/usr/bin/radosgw","-d",\
 "--no-mon-config",\
 "--id", "${ID}",\
 "--rgw-data", "/data/",\
-"--run-dir", "/run/",\
-"--rgw-backend-store", "dbstore"]
+"--run-dir", "/run/"]
+
+CMD ["--rgw-backend-store", "dbstore",\
+"--debug-rgw", "1"]

--- a/build/README.md
+++ b/build/README.md
@@ -10,7 +10,7 @@ Make sure you've installed the following applications:
 - podman
 - buildah
 
-Optionally, if you prefer building an `s3gw` container image with docker you will need:
+Optionally, if you prefer building an `s3gw` container image with Docker you will need:
 
 - docker
 
@@ -84,4 +84,17 @@ or, when using Docker:
 
 ```
 $ docker run -p 7480:7480 localhost/s3gw
+```
+By default, the container will run with the following arguments:
+
+```text
+--rgw-backend-store dbstore 
+--debug-rgw 1
+```
+
+You can override them passing different values when starting the container.  
+For example if want to increase `radosgw` logging verbosity, you could run:
+
+```shell
+$ podman run -p 7480:7480 localhost/s3gw --rgw-backend-store dbstore --debug-rgw 15
 ```

--- a/build/build-container.sh
+++ b/build/build-container.sh
@@ -41,7 +41,8 @@ buildah config --port 7480 \${ctr}
 buildah config --volume /data/ \${ctr}
 buildah config --env ID=s3gw \${ctr}
 buildah config --cmd '[]' \${ctr}
-buildah config --entrypoint '["radosgw", "-d", "--no-mon-config", "--rgw-backend-store", "dbstore", "--id", "\${ID}", "--rgw-data", "/data/", "--run-dir", "/run/"]' \${ctr}
+buildah config --entrypoint '["radosgw", "-d", "--no-mon-config", "--id", "\${ID}", "--rgw-data", "/data/", "--run-dir", "/run/"]' \${ctr}
+buildah config --cmd '["--rgw-backend-store", "dbstore", "--debug-rgw", "1"]' \${ctr}
 buildah commit --rm \${ctr} ${IMAGE_NAME}
 EOF
   buildah unshare sh ${tmpfile}


### PR DESCRIPTION
User can override --rgw-backend-store and --debug-rgw arguments.
They default respectively with values: dbstore, 1.

Signed-off-by: Giuseppe Baccini <giuseppe.baccini@suse.com>