### PR TITLE
Add rpms from install-deps.sh to Dockerfile.build-radosgw

### DIFF
--- a/build/Dockerfile.build-radosgw
+++ b/build/Dockerfile.build-radosgw
@@ -1,6 +1,24 @@
 FROM opensuse/tumbleweed
 
-RUN zypper -n install bash make git ccache cmake ninja
+RUN zypper -n install bash make git ccache cmake ninja jq
+# hard-coded in ceph's `install-deps.sh`
+RUN zypper -n install --no-recommends systemd-rpm-macros rpm-build
+# obtained by running `install-deps.sh` 2022-05-04
+RUN zypper -n install --no-recommends \
+  babeltrace-devel 'cmake>3.5' cryptsetup-devel cunit-devel fdupes \
+  'fmt-devel>=6.2.1' fuse-devel gcc-c++ golang-github-prometheus-prometheus \
+  gperf 'gperftools-devel>=2.4' keyutils-devel libaio-devel \
+  'libblkid-devel>=2.17' libbz2-devel libcap-ng-devel libcurl-devel \
+  libexpat-devel libicu-devel 'liblz4-devel>=1.7' libnl3-devel liboath-devel \
+  libopenssl-devel libpmem-devel libpmemobj-devel 'libthrift-devel>=0.13.0' \
+  libtool libxml2-devel lttng-ust-devel lua-devel lua54-luarocks make \
+  memory-constraints mozilla-nss-devel nasm ncurses-devel net-tools ninja \
+  openldap2-devel patch perl pkgconfig 'pkgconfig(libudev)' \
+  'pkgconfig(systemd)' 'pkgconfig(udev)' procps python3 python3-Cython \
+  python3-PrettyTable python3-PyYAML python3-Sphinx python3-devel \
+  python3-setuptools rdma-core-devel re2-devel snappy-devel sqlite-devel \
+  sudo systemd-rpm-macros valgrind-devel which xfsprogs-devel xmlstarlet
+
 COPY build-radosgw.sh /usr/bin/build-radosgw.sh
 
 VOLUME ["/srv/ceph"]


### PR DESCRIPTION
Currently, the build-radosgw container has a minimal set of packages necessary for the build, then later when you *run* the container, it calls out to `install-deps.sh` from the ceph source tree to install ceph's build dependencies (300+ rpms). This takes about 15 minutes (for me, at least, with my rural Tasmanian internet connection), and happens every time I run the build-radosgw container to build ceph.  If we put all these dependencies inside Dockerfile.build-radosgw instead, they only get downloaded once, when building that container.  We still run `install-deps.sh` in case any new dependencies have been added to ceph in the meantime, but at least we'll have almost all of them upfront.

~I've also added mirrorsorcerer which updates the zypper repos to whichever mirror is closest to you when you build the container.~

Signed-off-by: Tim Serong <tserong@suse.com>