### PR TITLE
Cleanup build script.

### DIFF
--- a/build/Dockerfile.build-container
+++ b/build/Dockerfile.build-container
@@ -2,27 +2,29 @@ FROM opensuse/tumbleweed
 LABEL Name=s3gw
 
 ARG ID=s3gw
-ENV ID=$ID
+ENV ID=${ID}
 
 RUN zypper -n install libblkid1 \
-libexpat1 \ 
-libtcmalloc4 \
-libfmt8 \
-libibverbs1 \
-librdmacm1 \ 
-liboath0 \
-libicu71
+  libexpat1 \
+  libtcmalloc4 \
+  libfmt8 \
+  libibverbs1 \
+  librdmacm1 \
+  liboath0 \
+  libicu71
 
 RUN mkdir -p /data
 
 COPY ./bin/radosgw /usr/bin/radosgw
 COPY ./lib/*.so* /usr/lib64/
 
-ENTRYPOINT [ "/usr/bin/radosgw","-d",\
-"--no-mon-config",\
-"--id", "${ID}",\
-"--rgw-data", "/data/",\
-"--run-dir", "/run/"]
+EXPOSE 7480
 
-CMD ["--rgw-backend-store", "dbstore",\
-"--debug-rgw", "1"]
+VOLUME ["/data"]
+ENTRYPOINT ["/usr/bin/radosgw", "-d", \
+  "--no-mon-config", \
+  "--id", "${ID}", \
+  "--rgw-data", "/data/", \
+  "--run-dir", "/run/"]
+CMD ["--rgw-backend-store", "dbstore", \
+  "--debug-rgw", "1"]

--- a/build/build-container.sh
+++ b/build/build-container.sh
@@ -2,61 +2,31 @@
 
 set -e
 
-BASE_IMAGE=${BASE_IMAGE:-"registry.opensuse.org/opensuse/tumbleweed:latest"}
 IMAGE_NAME=${IMAGE_NAME:-"s3gw"}
 CEPH_DIR=$(realpath ${CEPH_DIR:-"../../ceph/"})
-INSTALL_PACKAGES=${INSTALL_PACKAGES:-"libblkid1 libexpat1 libtcmalloc4 libfmt8 libibverbs1 librdmacm1 liboath0 libicu71"}
 CONTAINER_ENGINE=${CONTAINER_ENGINE:-"podman"}
 
 registry=
 registry_args=
 
-check_deps() {
-	if [ ! $(which buildah) ]; then
-	  echo 'Unable to find "buildah". Please make sure it is installed.'
-	  exit 1
-	fi
-}
-
 build_container_image() {
   echo "Building container image ..."
-  echo "BASE_IMAGE=${BASE_IMAGE}"
-  echo "IMAGE_NAME=${IMAGE_NAME}"
-  echo "CEPH_DIR=${CEPH_DIR}"
-  echo "CONTAINER_ENGINE=${CONTAINER_ENGINE}"
-
   case ${CONTAINER_ENGINE} in
-    podman)
+  podman)
+    podman build -t ${IMAGE_NAME} -f ./Dockerfile.build-container ${CEPH_DIR}/build
+    ;;
+  docker)
+    docker build -t localhost/${IMAGE_NAME} -f ./Dockerfile.build-container ${CEPH_DIR}/build
+    ;;
+  esac
+}
 
-  tmpfile=$(mktemp)
-  cat > ${tmpfile} << EOF
-ctr=\$(buildah from ${BASE_IMAGE})
-buildah run \${ctr} /bin/sh -c 'zypper -n install ${INSTALL_PACKAGES}'
-mnt=\$(buildah mount \${ctr})
-mkdir -p \${mnt}/data/
-cp --verbose ${CEPH_DIR}/build/bin/radosgw \${mnt}/usr/bin/radosgw
-cp --verbose --no-dereference ${CEPH_DIR}/build/lib/*.so* \${mnt}/usr/lib64/
-buildah unmount \${ctr}
-buildah config --port 7480 \${ctr}
-buildah config --volume /data/ \${ctr}
-buildah config --env ID=s3gw \${ctr}
-buildah config --cmd '[]' \${ctr}
-buildah config --entrypoint '["radosgw", "-d", "--no-mon-config", "--id", "\${ID}", "--rgw-data", "/data/", "--run-dir", "/run/"]' \${ctr}
-buildah config --cmd '["--rgw-backend-store", "dbstore", "--debug-rgw", "1"]' \${ctr}
-buildah commit --rm \${ctr} ${IMAGE_NAME}
-EOF
-  buildah unshare sh ${tmpfile}
-  rm -f ${tmpfile}
-
+push_container_image() {
   if [ -n "${registry}" ]; then
-    buildah push ${registry_args} localhost/${IMAGE_NAME} \
+    echo "Pushing container image to registry ..."
+    ${CONTAINER_ENGINE} push ${registry_args} localhost/${IMAGE_NAME} \
       ${registry}/${IMAGE_NAME}
   fi
-      ;;
-    docker)
-    docker build -t localhost/${IMAGE_NAME} -f ./Dockerfile.build-container ${CEPH_DIR}/build
-      ;;
-  esac
 }
 
 while [ $# -ge 1 ]; do
@@ -72,7 +42,7 @@ while [ $# -ge 1 ]; do
   shift
 done
 
-check_deps
 build_container_image
+push_container_image
 
 exit 0


### PR DESCRIPTION
- Use Dockerfile for podman and docker to reduce duplicate code.
- Add missing options in Dockerfile.

Signed-off-by: Volker Theile <vtheile@suse.com>