### PR TITLE
k8s environment improvements

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,10 +1,9 @@
 # s3gw environment
 
-You can quickly run the `s3gw` container alongside with a Longhorn installation
-by following this guide.  
-You will get a fully functional Kubernetes cluster installed on top of a set of virtual
-machines.  
-If you are looking for a more lightweight environment, please refer to our [K3s section](../k3s/README.md).
+Follow this guide if you wish to run an `s3gw` image on the latest stable Kubernetes release.  
+You will be able to quickly build a cluster installed on a set of virtual machines.  
+You will have a certain degree of choice in terms of customization options.  
+If you are looking for a more lightweight environment, please refer to our [K3s section](../k3s).
 
 ## Table of Contents
 
@@ -71,6 +70,9 @@ WORKER_CPU                  : The CPU amount used by a worker node (Vagrant form
 WORKER_DISK                 : yes/no, when yes a disk will be allocated for the worker node
 WORKER_DISK_SIZE            : The disk size allocated for a worker node (Vagrant format)
 CONTAINER_ENGINE            : The host's local container engine used to build the s3gw container (podman/docker)
+STOP_AFTER_BOOTSTRAP        : yes/no, when yes stop the provisioning just after the bootstrapping phase
+START_LOCAL_REGISTRY        : yes/no, when yes start a local insecure image registry at admin.local:5000
+S3GW_IMAGE                  : The s3gw's container image used when deploying the application on k8s
 ```
 
 So, you could start a more specialized build with:
@@ -141,22 +143,23 @@ When connecting to a worker node be sure to match the `WORKER_COUNT` value with 
 There are currently 2 services exposed with a Kubernetes ingress, each one is allocated on a separate host domain:
 
 * Longhorn dashboard, on domain: `longhorn.local`
-* s3gw, on domain: `s3gw.local`
+* s3gw, on domain: `s3gw.local` and `s3gw-no-tls.local`
 
-Host domains are exposed with a `nodePort` service listening on port `30443`.  
+Host domains are exposed with a `nodePort` service listening on ports `30443` (https) and `30080` (http).  
 You are required to resolve these domains with the external `ip` of one of the nodes of the cluster.  
 
 For example, you can patch host's `/etc/hosts` file with:  
 
 ```text
-10.46.201.101   longhorn.local s3gw.local 
+10.46.201.101   longhorn.local s3gw.local s3gw-no-tls.local
 ```
 
-This will make domains `longhorn.local` and `s3gw.local` pointing to the `admin` node.  
+This will make domains `longhorn.local`, `s3gw.local` and `s3gw-no-tls.local` pointing to the `admin` node.  
 
 Services can now be accessed to:
 
 ```text
 https://longhorn.local:30443
 https://s3gw.local:30443
+http://s3gw-no-tls.local:30080
 ```

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -102,6 +102,19 @@ Be sure to match the `WORKER_COUNT` value with the one you used in the build pha
 Providing a lower value instead of the actual one will cause some allocated vm not
 to be released by Vagrant.
 
+## Starting the environment
+
+You can start a previously built environment with:
+
+```bash
+$ ./s3gwctl start
+Starting environment ...
+```
+
+Be sure to match the `WORKER_COUNT` value with the one you used in the build phase.  
+Providing a lower value instead of the actual one will cause some allocated vm not
+to start.
+
 ## Accessing the environment
 
 ### ssh

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -64,11 +64,13 @@ CIDR_NET                    : The CIDR subnet used by the Calico network plugin
 WORKER_COUNT                : The number of Kubernetes workers in the cluster
 ADMIN_MEM                   : The RAM amount used by the admin node (Vagrant format)
 ADMIN_CPU                   : The CPU amount used by the admin node (Vagrant format)
+ADMIN_DISK                  : yes/no, when yes a disk will be allocated for the admin node - this will be effective only for mono clusters
 ADMIN_DISK_SIZE             : The disk size allocated for the admin node (Vagrant format) - this will be effective only for mono clusters
 WORKER_MEM                  : The RAM amount used by a worker node (Vagrant format)
 WORKER_CPU                  : The CPU amount used by a worker node (Vagrant format)
+WORKER_DISK                 : yes/no, when yes a disk will be allocated for the worker node
 WORKER_DISK_SIZE            : The disk size allocated for a worker node (Vagrant format)
-LOCAL_CNT_ENG               : The host's local container engine used to build the s3gw container (podman/docker)
+CONTAINER_ENGINE            : The host's local container engine used to build the s3gw container (podman/docker)
 ```
 
 So, you could start a more specialized build with:

--- a/k8s/Vagrantfile
+++ b/k8s/Vagrantfile
@@ -11,13 +11,18 @@ WORKER_MEM = Integer(ENV["WORKER_MEM"] || "4096")
 WORKER_CPU = Integer(ENV["WORKER_CPU"] || "2")
 WORKER_DISK = ENV["WORKER_DISK"] || "no"
 WORKER_DISK_SIZE = ENV["WORKER_DISK_SIZE"] || "8G"
+STOP_AFTER_BOOTSTRAP = ENV["STOP_AFTER_BOOTSTRAP"] || "no"
+START_LOCAL_REGISTRY = ENV["START_LOCAL_REGISTRY"] || "no"
+S3GW_IMAGE = ENV["S3GW_IMAGE"] || "ghcr.io/aquarist-labs/s3gw:latest"
 
 ansible_groups = {
   "admins" => [
     "admin"
   ],
   "solo_admins" => [
-  ], 
+  ],
+  "registries" => [
+  ],
   "workers" => [
     "worker-[1:#{WORKER_COUNT}]"
   ]
@@ -46,6 +51,10 @@ Vagrant.configure("2") do |config|
 		admin.vm.network "private_network", autostart: true, ip: "#{VM_NET}.#{VM_NET_LAST_OCTET_START}"
         admin.vm.hostname = "admin"
 
+		if START_LOCAL_REGISTRY == "yes"
+			ansible_groups["registries"] << "admin"
+		end
+
 		if WORKER_COUNT == 0
 			ansible_groups["solo_admins"] << "admin"
 			admin.vm.provision :ansible do |ansible|
@@ -57,41 +66,44 @@ Vagrant.configure("2") do |config|
 					cidr_net: CIDR_NET
 				}
 			end
-			admin.vm.provision :ansible do |ansible|
-				ansible.limit = "all"
-				ansible.playbook = "playbooks/k8s-install.yaml"
-				ansible.groups = ansible_groups
-				ansible.extra_vars = {
-					worker_count: 0,
-					cidr_net: CIDR_NET
-				}
-			end
-			admin.vm.provision :ansible do |ansible|
-				ansible.limit = "all"
-				ansible.playbook = "playbooks/lh-deploy.yaml"
-				ansible.groups = ansible_groups
-				ansible.extra_vars = {
-					worker_count: 0,
-					cidr_net: CIDR_NET
-				}
-			end
-			admin.vm.provision :ansible do |ansible|
-				ansible.limit = "all"
-				ansible.playbook = "playbooks/s3gw-deploy.yaml"
-				ansible.groups = ansible_groups
-				ansible.extra_vars = {
-					worker_count: 0,
-					cidr_net: CIDR_NET
-				}
-			end
-			admin.vm.provision :ansible do |ansible|
-				ansible.limit = "all"
-				ansible.playbook = "playbooks/ingress-deploy.yaml"
-				ansible.groups = ansible_groups
-				ansible.extra_vars = {
-					worker_count: 0,
-					cidr_net: CIDR_NET
-				}
+			if(STOP_AFTER_BOOTSTRAP == "no")
+				admin.vm.provision :ansible do |ansible|
+					ansible.limit = "all"
+					ansible.playbook = "playbooks/k8s-install.yaml"
+					ansible.groups = ansible_groups
+					ansible.extra_vars = {
+						worker_count: 0,
+						cidr_net: CIDR_NET
+					}
+				end
+				admin.vm.provision :ansible do |ansible|
+					ansible.limit = "all"
+					ansible.playbook = "playbooks/lh-deploy.yaml"
+					ansible.groups = ansible_groups
+					ansible.extra_vars = {
+						worker_count: 0,
+						cidr_net: CIDR_NET
+					}
+				end
+				admin.vm.provision :ansible do |ansible|
+					ansible.limit = "all"
+					ansible.playbook = "playbooks/s3gw-deploy.yaml"
+					ansible.groups = ansible_groups
+					ansible.extra_vars = {
+						worker_count: 0,
+						cidr_net: CIDR_NET,
+						s3gw_image: S3GW_IMAGE
+					}
+				end
+				admin.vm.provision :ansible do |ansible|
+					ansible.limit = "all"
+					ansible.playbook = "playbooks/ingress-deploy.yaml"
+					ansible.groups = ansible_groups
+					ansible.extra_vars = {
+						worker_count: 0,
+						cidr_net: CIDR_NET
+					}
+				end
 			end
 		end
     end
@@ -124,41 +136,44 @@ Vagrant.configure("2") do |config|
 							cidr_net: CIDR_NET
 						}
 					end
-					worker.vm.provision :ansible do |ansible|
-						ansible.limit = "all"
-						ansible.playbook = "playbooks/k8s-install.yaml"
-						ansible.groups = ansible_groups
-						ansible.extra_vars = {
-							worker_count: WORKER_COUNT,
-							cidr_net: CIDR_NET
-						}
-					end
-					worker.vm.provision :ansible do |ansible|
-						ansible.limit = "all"
-						ansible.playbook = "playbooks/lh-deploy.yaml"
-						ansible.groups = ansible_groups
-						ansible.extra_vars = {
-							worker_count: 0,
-							cidr_net: CIDR_NET
-						}
-					end
-					worker.vm.provision :ansible do |ansible|
-						ansible.limit = "all"
-						ansible.playbook = "playbooks/s3gw-deploy.yaml"
-						ansible.groups = ansible_groups
-						ansible.extra_vars = {
-							worker_count: 0,
-							cidr_net: CIDR_NET
-						}
-					end
-					worker.vm.provision :ansible do |ansible|
-						ansible.limit = "all"
-						ansible.playbook = "playbooks/ingress-deploy.yaml"
-						ansible.groups = ansible_groups
-						ansible.extra_vars = {
-							worker_count: 0,
-							cidr_net: CIDR_NET
-						}
+					if(STOP_AFTER_BOOTSTRAP == "no")
+						worker.vm.provision :ansible do |ansible|
+							ansible.limit = "all"
+							ansible.playbook = "playbooks/k8s-install.yaml"
+							ansible.groups = ansible_groups
+							ansible.extra_vars = {
+								worker_count: WORKER_COUNT,
+								cidr_net: CIDR_NET
+							}
+						end
+						worker.vm.provision :ansible do |ansible|
+							ansible.limit = "all"
+							ansible.playbook = "playbooks/lh-deploy.yaml"
+							ansible.groups = ansible_groups
+							ansible.extra_vars = {
+								worker_count: WORKER_COUNT,
+								cidr_net: CIDR_NET
+							}
+						end
+						worker.vm.provision :ansible do |ansible|
+							ansible.limit = "all"
+							ansible.playbook = "playbooks/s3gw-deploy.yaml"
+							ansible.groups = ansible_groups
+							ansible.extra_vars = {
+								worker_count: WORKER_COUNT,
+								cidr_net: CIDR_NET,
+								s3gw_image: S3GW_IMAGE
+							}
+						end
+						worker.vm.provision :ansible do |ansible|
+							ansible.limit = "all"
+							ansible.playbook = "playbooks/ingress-deploy.yaml"
+							ansible.groups = ansible_groups
+							ansible.extra_vars = {
+								worker_count: WORKER_COUNT,
+								cidr_net: CIDR_NET
+							}
+						end
 					end
 				end
 			end

--- a/k8s/Vagrantfile
+++ b/k8s/Vagrantfile
@@ -5,9 +5,11 @@ CIDR_NET = ENV["CIDR_NET"] || "172.22.0.0"
 WORKER_COUNT = Integer(ENV["WORKER_COUNT"] || "1")
 ADMIN_MEM = Integer(ENV["ADMIN_MEM"] || "4096")
 ADMIN_CPU = Integer(ENV["ADMIN_CPU"] || "2")
+ADMIN_DISK = ENV["ADMIN_DISK"] || "no"
 ADMIN_DISK_SIZE = ENV["ADMIN_DISK_SIZE"] || "8G"
 WORKER_MEM = Integer(ENV["WORKER_MEM"] || "4096")
 WORKER_CPU = Integer(ENV["WORKER_CPU"] || "2")
+WORKER_DISK = ENV["WORKER_DISK"] || "no"
 WORKER_DISK_SIZE = ENV["WORKER_DISK_SIZE"] || "8G"
 
 ansible_groups = {
@@ -35,7 +37,7 @@ Vagrant.configure("2") do |config|
 		admin.vm.provider "libvirt" do |lv|
 		  lv.memory = ADMIN_MEM
 		  lv.cpus = ADMIN_CPU
-		  if WORKER_COUNT == 0
+		  if WORKER_COUNT == 0 && ADMIN_DISK == "yes"
 		  	lv.storage :file, size: ADMIN_DISK_SIZE, type: 'qcow2', serial: "6646200"
 		  end
 		end
@@ -101,7 +103,9 @@ Vagrant.configure("2") do |config|
 				worker.vm.provider "libvirt" do |lv|
 					lv.memory = WORKER_MEM
 					lv.cpus = WORKER_CPU
-					lv.storage :file, size: WORKER_DISK_SIZE, type: 'qcow2', serial: "674620#{i}"
+					if WORKER_DISK == "yes"
+						lv.storage :file, size: WORKER_DISK_SIZE, type: 'qcow2', serial: "674620#{i}"
+					end
 				end
 
 				worker.vm.box = IMAGE_NAME

--- a/k8s/ingresses/s3gw-ingress-no-tls.yaml
+++ b/k8s/ingresses/s3gw-ingress-no-tls.yaml
@@ -1,0 +1,50 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: s3gw-no-tls-ingress
+  namespace: s3gw-system
+  annotations:
+
+    # We need to configure the location '/' with he following snippet.
+    # The real need is to provide this directive:
+    #
+    #   proxy_set_header Host $http_host;
+    #
+    # This ensures that http's header contains the host field as passed by the client.
+    # The S3's HMAC signature is computed by the client on a set of fields that include
+    # the host as specified by the client. 
+    # So if the http header's host is in the form: 'host:port' it won't be equal when 
+    # received by s3gw (and therefore HMAC will not match).
+    # NGINX by default changes the http header's host with $host and that does not include
+    # the port.
+    nginx.org/server-snippets: |
+      location / {
+            set $service "s3gw-service"; 
+            proxy_http_version 1.1;
+            proxy_connect_timeout 60s;
+            proxy_read_timeout 60s;
+            proxy_send_timeout 60s;
+            client_max_body_size 0;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Forwarded-Port $server_port;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_buffering on;
+            proxy_pass http://s3gw-system-s3gw-ingress-s3gw.local-s3gw-service-80;
+        }
+spec:
+  ingressClassName: nginx
+  rules: 
+  - host: s3gw-no-tls.local
+    http:
+      paths:
+        # We need to add a /foo location because we need to define a backend.
+      - path: /foo
+        pathType: Prefix
+        backend:
+          service:
+            name: s3gw-service
+            port:
+              number: 80

--- a/k8s/ingresses/s3gw-ingress.yaml
+++ b/k8s/ingresses/s3gw-ingress.yaml
@@ -24,7 +24,7 @@ metadata:
             proxy_connect_timeout 60s;
             proxy_read_timeout 60s;
             proxy_send_timeout 60s;
-            client_max_body_size 1m;
+            client_max_body_size 0;
             proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/k8s/playbooks/bootstrap.yaml
+++ b/k8s/playbooks/bootstrap.yaml
@@ -1,4 +1,4 @@
-- name: bootstrap-1
+- name: Install Packages
   hosts: all
   become: true
   tasks:
@@ -16,7 +16,7 @@
             - gnupg-agent
             - software-properties-common            
 
-- name: bootstrap-2
+- name: Container Runtime
   hosts: all
   become: true
   tasks:
@@ -31,19 +31,18 @@
         repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable
         state: present
 
-    - name: Install Docker
+    - name: Install container runtime
       apt: 
         name: "{{ packages }}"
         state: present
         update_cache: yes
       vars:
         packages:
+            - containerd.io
             - docker-ce 
             - docker-ce-cli 
-            - docker-compose
-            - containerd.io
 
-    - name: Patching daemon.json
+    - name: Patching docker/daemon.json
       copy:
         dest: "/etc/docker/daemon.json"
         content: |
@@ -51,10 +50,64 @@
             "exec-opts": ["native.cgroupdriver=systemd"],
             "insecure-registries" : ["admin:5000"]
             }
+
+    - name: Patching /etc/modules-load.d/containerd.conf
+      copy:
+        dest: "/etc/modules-load.d/containerd.conf"
+        content: |
+            overlay
+            br_netfilter
+
+    - name: Add the overlay module
+      modprobe:
+        name: overlay
+        state: present
+
+    - name: Add the br_netfilter module
+      modprobe:
+        name: br_netfilter
+        state: present
+
+    - name: Patching /etc/sysctl.d/99-kubernetes-cri.conf
+      copy:
+        dest: "/etc/sysctl.d/99-kubernetes-cri.conf"
+        content: |
+            net.bridge.bridge-nf-call-iptables  = 1
+            net.ipv4.ip_forward                 = 1
+            net.bridge.bridge-nf-call-ip6tables = 1
+
+    - name: Apply sysctl params without reboot
+      command: sysctl --system
+
+    - name: Patching /etc/containerd/config.toml
+      copy:
+        dest: "/etc/containerd/config.toml"
+        content: |
+            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+              SystemdCgroup = true
             
-    - name: Restart Docker
+            version = 2
+
+            [plugins."io.containerd.grpc.v1.cri".registry]
+              config_path = "/etc/containerd/certs.d"
+
+    - name: Create /etc/containerd/certs.d/admin.local directory
+      file:
+        path: /etc/containerd/certs.d/admin.local
+        state: directory
+
+    - name: Patching /etc/containerd/certs.d/admin.local/hosts.toml
+      copy:
+        dest: "/etc/containerd/certs.d/admin.local/hosts.toml"
+        content: |
+            [host."http://admin.local:5000"]
+              capabilities = ["pull", "resolve", "push"]
+              skip_verify = true
+
+    - name: Restart containerd
       service:
-        name: docker
+        name: containerd
         state: restarted
         daemon_reload: yes
 
@@ -62,6 +115,12 @@
       user:
         name: vagrant
         group: docker
+
+    - name: Restart Docker
+      service:
+        name: docker
+        state: restarted
+        daemon_reload: yes
 
     - name: Remove swapfile from /etc/fstab
       mount:
@@ -75,8 +134,8 @@
     - name: Disable swap
       command: swapoff -a
 
-- name: bootstrap-3
-  hosts: admins
+- name: Start Local Registry [optional]
+  hosts: registries
   become: yes
   tasks:
 
@@ -96,7 +155,7 @@
         - docker image rm admin:5000/s3gw
         - rm -rf s3gw.tar
 
-- name: bootstrap-4
+- name: Local DNS
   hosts: all
   gather_facts: yes
   tasks:

--- a/k8s/playbooks/ingress-deploy.yaml
+++ b/k8s/playbooks/ingress-deploy.yaml
@@ -52,6 +52,7 @@
         - kubectl apply -f /home/vagrant/ingresses/lh-ingress.yaml
         - kubectl apply -f /home/vagrant/ingresses/s3gw-secret.yaml
         - kubectl apply -f /home/vagrant/ingresses/s3gw-ingress.yaml
+        - kubectl apply -f /home/vagrant/ingresses/s3gw-ingress-no-tls.yaml
 
     - name: Create a Service for the Ingress Controller Pods
       command: kubectl apply -f /home/vagrant/ingresses/nginx-nodeport.yaml

--- a/k8s/playbooks/k8s-install.yaml
+++ b/k8s/playbooks/k8s-install.yaml
@@ -1,4 +1,4 @@
-- name: k8s-1
+- name: Install k8s Packages
   hosts: all
   become: true
   tasks:
@@ -47,12 +47,12 @@
           - /bin/bash -c "sudo echo 'alias k=kubectl' >> /home/vagrant/.bashrc"
           - /bin/bash -c "sudo echo 'complete -F __start_kubectl k' >> /home/vagrant/.bashrc"      
   
-- name: k8s-2
+- name: Kubeadm
   hosts: admins
   become: true
   tasks:
     - name: Initialize Kubernetes cluster using kubeadm
-      command: kubeadm init --apiserver-advertise-address="{{ ansible_facts['eth1']['ipv4']['address'] }}" --apiserver-cert-extra-sans="{{ ansible_facts['eth1']['ipv4']['address'] }}" --node-name master --pod-network-cidr={{ cidr_net }}/16 --ignore-preflight-errors=Swap
+      command: kubeadm init --apiserver-advertise-address="{{ ansible_facts['eth1']['ipv4']['address'] }}" --apiserver-cert-extra-sans="{{ ansible_facts['eth1']['ipv4']['address'] }}" --node-name admin --pod-network-cidr={{ cidr_net }}/16 --ignore-preflight-errors=Swap
 
     - name: Setup kubeconfig for vagrant user
       command: "{{ item }}"
@@ -90,7 +90,7 @@
     - name: Copy join command to local file
       local_action: copy content="{{ join_command.stdout_lines[0] }}" dest="./join-command"
 
-- name: k8s-3
+- name: Join
   hosts: workers
   become: true
   tasks:
@@ -108,18 +108,21 @@
     - name: Copy kubeconfig to local file
       copy: src=./admin.conf dest=/home/vagrant/.kube/config mode=0777
 
-- name: k8s-4
+- name: Probe admin
   hosts: admins
   tasks:
     - name: Wait for admin to be ready 
-      command: kubectl get nodes master
+      command: kubectl get nodes admin
       register: result
       until: result.stdout.find("NotReady") == -1
       retries: 25
       delay: 5
 
-- name: k8s-5
+- name: Untaint admin
   hosts: solo_admins
   tasks:
     - name: Untaint admin for pod scheduling
-      command: kubectl taint nodes --all node-role.kubernetes.io/master-
+      command: "{{ item }}"
+      with_items:
+          - kubectl taint node --all node-role.kubernetes.io/master-
+          - kubectl taint node --all node-role.kubernetes.io/control-plane-

--- a/k8s/playbooks/lh-deploy.yaml
+++ b/k8s/playbooks/lh-deploy.yaml
@@ -1,4 +1,4 @@
-- name: longhorn-1
+- name: Deploy Longhorn
   hosts: admins
   tasks:
   

--- a/k8s/playbooks/s3gw-deploy.yaml
+++ b/k8s/playbooks/s3gw-deploy.yaml
@@ -5,6 +5,12 @@
     - name: Copy s3gw cfg to local dir
       copy: src=../s3gw dest=/home/vagrant mode=0777
 
+    - name: Set S3GW_IMAGE in s3gw-deployment.yaml
+      replace:
+        path: /home/vagrant/s3gw/s3gw-deployment.yaml
+        regexp: '##S3GW_IMAGE##'
+        replace: "{{ s3gw_image }}"
+
     - name: Deploy s3gw
       command: "{{ item }}"
       with_items:

--- a/k8s/s3gw/s3gw-deployment.yaml
+++ b/k8s/s3gw/s3gw-deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: s3gw
-          image: admin:5000/s3gw:latest
+          image: ##S3GW_IMAGE##
           args: ["--rgw-backend-store", $(RGW_BACKEND_STORE), "--debug-rgw", $(DEBUG_RGW)]
           envFrom:
             - configMapRef:

--- a/k8s/s3gwctl
+++ b/k8s/s3gwctl
@@ -17,6 +17,13 @@ export WORKER_DISK=${WORKER_DISK:-"no"}
 export WORKER_DISK_SIZE=${WORKER_DISK_SIZE:-"8G"}
 export CONTAINER_ENGINE=${CONTAINER_ENGINE:-"podman"}
 
+start_env() {
+  echo "Starting environment ..."
+  echo "WORKER_COUNT=${WORKER_COUNT}"
+   
+  vagrant up
+}
+
 build_env() {
   echo "IMAGE_NAME=${IMAGE_NAME}"
   echo "VM_NET=${VM_NET}"
@@ -69,6 +76,10 @@ if [ $# -eq 0 ]; then
   build_env
 elif [ $# -eq 1 ]; then
   case $1 in
+    start)
+      start_env
+      break
+      ;;  
     build)
       build_env
       break

--- a/k8s/s3gwctl
+++ b/k8s/s3gwctl
@@ -9,11 +9,13 @@ export CIDR_NET=${CIDR_NET:-"172.22.0.0"}
 export WORKER_COUNT=${WORKER_COUNT:-"1"}
 export ADMIN_MEM=${ADMIN_MEM:-"4096"}
 export ADMIN_CPU=${ADMIN_CPU:-"2"}
+export ADMIN_DISK=${ADMIN_DISK:-"no"}
 export ADMIN_DISK_SIZE=${ADMIN_DISK_SIZE:-"8G"}
 export WORKER_MEM=${WORKER_MEM:-"4096"}
 export WORKER_CPU=${WORKER_CPU:-"2"}
+export WORKER_DISK=${WORKER_DISK:-"no"}
 export WORKER_DISK_SIZE=${WORKER_DISK_SIZE:-"8G"}
-export LOCAL_CNT_ENG=${LOCAL_CNT_ENG:-"podman"}
+export CONTAINER_ENGINE=${CONTAINER_ENGINE:-"podman"}
 
 build_env() {
   echo "IMAGE_NAME=${IMAGE_NAME}"
@@ -23,17 +25,19 @@ build_env() {
   echo "WORKER_COUNT=${WORKER_COUNT}"
   echo "ADMIN_MEM=${ADMIN_MEM}"
   echo "ADMIN_CPU=${ADMIN_CPU}" 
+  echo "ADMIN_DISK=${ADMIN_DISK}"
   echo "ADMIN_DISK_SIZE=${ADMIN_DISK_SIZE}"
   echo "WORKER_MEM=${WORKER_MEM}"
   echo "WORKER_CPU=${WORKER_CPU}"
+  echo "WORKER_DISK=${WORKER_DISK}" 
   echo "WORKER_DISK_SIZE=${WORKER_DISK_SIZE}" 
-  echo "LOCAL_CNT_ENG=${LOCAL_CNT_ENG}" 
+  echo "CONTAINER_ENGINE=${CONTAINER_ENGINE}" 
 
   echo "Saving s3gw container image locally ..."
   rm -rf ./s3gw.tar
-  if [ $LOCAL_CNT_ENG = "podman" ]; then
+  if [ $CONTAINER_ENGINE = "podman" ]; then
     podman save -o ./s3gw.tar s3gw:latest
-  elif [ $LOCAL_CNT_ENG = "docker" ]; then
+  elif [ $CONTAINER_ENGINE = "docker" ]; then
     docker save --output ./s3gw.tar localhost/s3gw:latest
   fi
   echo "Saved"

--- a/k8s/s3gwctl
+++ b/k8s/s3gwctl
@@ -16,6 +16,9 @@ export WORKER_CPU=${WORKER_CPU:-"2"}
 export WORKER_DISK=${WORKER_DISK:-"no"}
 export WORKER_DISK_SIZE=${WORKER_DISK_SIZE:-"8G"}
 export CONTAINER_ENGINE=${CONTAINER_ENGINE:-"podman"}
+export STOP_AFTER_BOOTSTRAP=${STOP_AFTER_BOOTSTRAP:-"no"}
+export START_LOCAL_REGISTRY=${START_LOCAL_REGISTRY:-"no"}
+export S3GW_IMAGE=${S3GW_IMAGE:-"ghcr.io/aquarist-labs/s3gw:latest"}
 
 start_env() {
   echo "Starting environment ..."
@@ -36,26 +39,31 @@ build_env() {
   echo "ADMIN_DISK_SIZE=${ADMIN_DISK_SIZE}"
   echo "WORKER_MEM=${WORKER_MEM}"
   echo "WORKER_CPU=${WORKER_CPU}"
-  echo "WORKER_DISK=${WORKER_DISK}" 
-  echo "WORKER_DISK_SIZE=${WORKER_DISK_SIZE}" 
-  echo "CONTAINER_ENGINE=${CONTAINER_ENGINE}" 
+  echo "WORKER_DISK=${WORKER_DISK}"
+  echo "WORKER_DISK_SIZE=${WORKER_DISK_SIZE}"
+  echo "CONTAINER_ENGINE=${CONTAINER_ENGINE}"
+  echo "STOP_AFTER_BOOTSTRAP=${STOP_AFTER_BOOTSTRAP}"
+  echo "START_LOCAL_REGISTRY=${START_LOCAL_REGISTRY}"
+  echo "S3GW_IMAGE=${S3GW_IMAGE}"
 
-  echo "Saving s3gw container image locally ..."
-  rm -rf ./s3gw.tar
-  if [ $CONTAINER_ENGINE = "podman" ]; then
-    podman save -o ./s3gw.tar s3gw:latest
-  elif [ $CONTAINER_ENGINE = "docker" ]; then
-    docker save --output ./s3gw.tar localhost/s3gw:latest
+  if [ $START_LOCAL_REGISTRY = "yes" ]; then
+    echo "Saving s3gw container image locally ..."
+    rm -rf ./s3gw.tar
+    if [ $CONTAINER_ENGINE = "podman" ]; then
+      podman save -o ./s3gw.tar s3gw:latest
+    elif [ $CONTAINER_ENGINE = "docker" ]; then
+      docker save --output ./s3gw.tar localhost/s3gw:latest
+    fi
+    echo "Saved"
   fi
-  echo "Saved"
 
   echo "Building environment ..."
   vagrant up
   echo "Built"
 
-  echo "Removing previously saved s3gw container image ..."
+  echo "Cleaning ..."
   rm -rf ./s3gw.tar
-  echo "Removed"
+  echo "Cleaned"
 }
 
 destroy_env() {


### PR DESCRIPTION
Various Improvements on k8s environment:
    
    - k8s stable upgraded to 1.24.0 from 1.23.x line;
      with this release Docker support has been removed.
      Due to this, project playbooks have been updated in order
      to configure containerd as CRI interface for k8s.

    - Added some options when building the environment.
      A notable option is that now you can choose the s3gw
      image to use in the deployment.

    - Added start command in s3gwctl
    
    - Added no-tls ingress for s3gw

    - Added the ability to choose if allocate a disk for admin/worker on cluster
    
    - Set client_max_body_size to 0 for s3gw's ingress
    
    - Some cleaning

Signed-off-by: Giuseppe Baccini <giuseppe.baccini@suse.com>