### PR TITLE
Strip unnecessary data from radosgw binary.

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,15 @@ file system is correct, e.g. `../../ceph`, `~/git/ceph`, ...
 $ podman run --replace --name build-radosgw -v ../../ceph/:/srv/ceph/ localhost/build-radosgw
 ```
 
+By default, the `radosgw` binary file will be build in `Debug` mode. For production
+builds set the environment variable `CMAKE_BUILD_TYPE` to `Release`, `RelWithDebInfo`
+or `MinSizeRel`. Check the [CMAKE_BUILD_TYPE documentation](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+for more information.
+
+```
+$ podman run --replace --name build-radosgw -e CMAKE_BUILD_TYPE="MinSizeRel" -v ../../ceph/:/srv/ceph/ localhost/build-radosgw
+```
+
 ### Build the s3gw container image
 If the Ceph `radosgw` binary is compiled, the container image can be build
 with the following commands:
@@ -210,7 +219,7 @@ By default, the container will run with the following arguments:
 ```
 
 You can override them passing different values when starting the container.
-For example if want to increase `radosgw` logging verbosity, you could run:
+For example if you want to increase `radosgw` logging verbosity, you could run:
 
 ```shell
 $ podman run -p 7480:7480 localhost/s3gw --rgw-backend-store dbstore --debug-rgw 15

--- a/build/Dockerfile.build-radosgw
+++ b/build/Dockerfile.build-radosgw
@@ -1,6 +1,6 @@
 FROM opensuse/tumbleweed
 
-RUN zypper -n install bash make git ccache cmake ninja jq
+RUN zypper -n install bash make git ccache cmake ninja jq binutils
 # hard-coded in ceph's `install-deps.sh`
 RUN zypper -n install --no-recommends systemd-rpm-macros rpm-build
 # obtained by running `install-deps.sh` 2022-05-04

--- a/build/build-radosgw.sh
+++ b/build/build-radosgw.sh
@@ -12,8 +12,8 @@ CEPH_CMAKE_ARGS="-DWITH_MANPAGE=OFF -DWITH_OPENLDAP=OFF -DWITH_LTTNG=OFF ${CEPH_
 CEPH_CMAKE_ARGS="-DWITH_RDMA=OFF ${CEPH_CMAKE_ARGS}"
 NPROC=${NPROC:-$(nproc --ignore=2)}
 
-build_radosgw_binary() {
-  echo "Building radosgw binary ..."
+build_radosgw() {
+  echo "Building radosgw ..."
   echo "CEPH_DIR=${CEPH_DIR}"
   echo "NPROC=${NPROC}"
 
@@ -39,6 +39,15 @@ build_radosgw_binary() {
   ninja -j${NPROC} bin/radosgw
 }
 
-build_radosgw_binary
+strip_radosgw() {
+  echo "Stripping files ..."
+  strip --strip-debug --strip-unneeded \
+    --remove-section=.comment --remove-section=.note \
+    ${CEPH_DIR}/build/bin/radosgw \
+    ${CEPH_DIR}/build/lib/*.so
+}
+
+build_radosgw
+strip_radosgw
 
 exit 0

--- a/build/build-radosgw.sh
+++ b/build/build-radosgw.sh
@@ -2,9 +2,16 @@
 
 set -e
 
+# https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html
+# Release: Your typical release build with no debugging information and full optimization.
+# MinSizeRel: A special Release build optimized for size rather than speed.
+# RelWithDebInfo: Same as Release, but with debugging information.
+# Debug: Usually a classic debug build including debugging information, no optimization etc.
+CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-"Debug"}
+
 CEPH_DIR=$(realpath ${CEPH_DIR:-"/srv/ceph"})
 CEPH_CMAKE_ARGS="-DENABLE_GIT_VERSION=ON -DWITH_PYTHON3=3 -DWITH_CCACHE=ON ${CEPH_CMAKE_ARGS}"
-CEPH_CMAKE_ARGS="-DWITH_TESTS=OFF -DCMAKE_BUILD_TYPE=Release ${CEPH_CMAKE_ARGS}"
+CEPH_CMAKE_ARGS="-DWITH_TESTS=OFF -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} ${CEPH_CMAKE_ARGS}"
 CEPH_CMAKE_ARGS="-DWITH_RADOSGW_AMQP_ENDPOINT=OFF -DWITH_RADOSGW_KAFKA_ENDPOINT=OFF ${CEPH_CMAKE_ARGS}"
 CEPH_CMAKE_ARGS="-DWITH_RADOSGW_SELECT_PARQUET=OFF -DWITH_RADOSGW_MOTR=OFF ${CEPH_CMAKE_ARGS}"
 CEPH_CMAKE_ARGS="-DWITH_RADOSGW_DBSTORE=ON -DWITH_RADOSGW_LUA_PACKAGES=OFF ${CEPH_CMAKE_ARGS}"
@@ -16,6 +23,7 @@ build_radosgw() {
   echo "Building radosgw ..."
   echo "CEPH_DIR=${CEPH_DIR}"
   echo "NPROC=${NPROC}"
+  echo "CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
 
   export CCACHE_DIR="${CEPH_DIR}/build.ccache"
   if [ ! -d "${CCACHE_DIR}" ]; then
@@ -40,9 +48,11 @@ build_radosgw() {
 }
 
 strip_radosgw() {
+  [ "${CMAKE_BUILD_TYPE}" == "Debug" -o "${CMAKE_BUILD_TYPE}" == "RelWithDebInfo" ] && return 0
+
   echo "Stripping files ..."
   strip --strip-debug --strip-unneeded \
-    --remove-section=.comment --remove-section=.note \
+    --remove-section=.comment --remove-section=.note.* \
     ${CEPH_DIR}/build/bin/radosgw \
     ${CEPH_DIR}/build/lib/*.so
 }

--- a/env/setup_k3s.sh
+++ b/env/setup_k3s.sh
@@ -30,7 +30,7 @@ function apply() {
     error "Missing parameters to function apply." && \
     exit 1
 
-  echo "Creating ${desc}..."
+  echo "${desc}"
   k3s kubectl apply -f ./${yaml} || (
     error "Failed to create ${desc}."
     exit 1
@@ -51,7 +51,7 @@ function show_ingresses() {
 }
 
 function install_on_vm() {
-  echo "Proceding to install on a virtual machine"
+  echo "Proceeding to install on a virtual machine"
   WORKER_COUNT=0
   K8S_DISTRO=k3s
   source ./setup_k8s.sh build


### PR DESCRIPTION
Stripping the binary and shared libraries will reduce the size of the container image about 20MiB.

References:
- https://github.com/Debian/debhelper/blob/master/dh_strip
- https://www.thegeekstuff.com/2012/09/strip-command-examples/

Fixes: https://github.com/aquarist-labs/s3gw-core/issues/54

Signed-off-by: Volker Theile <vtheile@suse.com>