### PR TITLE
s3gw/tests: add rudimentary smoke tests and benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /.idea/
 .vagrant
+.vscode
+
+*.swp

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,4 @@
+s3gw-s3test-*
+s3gw-s3tests-*.json
+s3gw-status.git
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,77 @@
+# Testing s3gw
+
+In this directory one can find scripts to test `s3gw` in several different
+ways. Below is a description of each type of test.
+
+However, please note a commonality between the various tests: they require an
+existing gateway running somewhere accessible by the tests. This may be an
+`s3gw` container, or a `radosgw` running from a source repository. It doesn't
+matter whether these running on the local machine or on a remote host, as long
+as they are accessible to the tests.
+
+
+## smoke tests
+
+Basic test battery to smoke out errors and potential regressions.
+
+This script takes a mandatory argument in the form
+`ADDRESS[:PORT[/LOCATION]]`. For example, `127.0.0.1:7480/s3gw`, where we know
+we will be able to find the `radosgw`.
+
+At the moment, these tests mainly rely on `s3cmd`, which requires to be
+installed and available in the `PATH`.
+
+## s3tests
+
+Runs a comprehensive test battery against a running `radosgw`. It relies on
+[ceph/s3-tests](https://github.com/ceph/s3-tests), and will clone this
+repository for each test run.
+
+This script also takes a mandatory argument in the form `HOST[:PORT]`, which
+must be the address where the `radosgw` can be found. `PORT` defaults to
+`7480`.
+
+Each run will be kept in a directory of the form `s3gw-s3test-DATE-TESTID`.
+The cloned `ceph/s3-tests` repository, as well as logs, will be kept within
+this directory.
+
+### creating reports
+
+Test reports may be generated using the `create-s3tests-report.sh` script.
+This script requires the resulting log file from an `s3gw-s3tests.sh` run.
+
+The report is a `json` file containing relevant information about the run, and
+is meant to be shared via the
+[aquarist-labs/s3gw-status](https://github.com/aquarist-labs/s3gw-status)
+repository (see more information on the [project's README
+file](https://github.com/aquarist-labs/s3gw-status#readme).)
+
+Please check `create-s3tests-report.sh --help` for more information.
+
+## benchmarking
+
+With tracking our improvement over time in mind, we should be benchmarking
+`radosgw` with the file based backend `simplefile` we have been developing.
+This will allow us to identify early on potential performance regressions, as
+well as understand whether the changes we're making are actually having an
+impact, and at the desired scale.
+
+This script relies on [MinIO's warp tool](https://github.com/minio/warp). To
+run it will need this tool to be available on the user's `PATH`. That means
+having it installed with `go install github.com/minio/warp@latest`, and have
+the `GOPATH` (by default it should be `~/go/bin`) in the user's `PATH`.
+
+Again, this script will require a `HOST[:PORT]` parameter, similarly to the
+other tests, so `warp` knows where to find the `radosgw` being benchmarked.
+
+Additionally, this script takes one of three options: `--large`, writing 6000
+objects for 10 minutes; `--medium`, writing 1000 objects for 5 minutes; and
+`--small` for 50 objects during 1 minute.
+
+The test will run `wrap` 3 times, for object sizes of 1MiB, 10MiB, and 100MiB.
+
+Each time `wrap` is run, a file will be created containing the results of
+the benchmark. This file can later on be used to compare results between runs.
+For more information, please check `warp`'s help.
+
+

--- a/tests/create-s3tests-report.sh
+++ b/tests/create-s3tests-report.sh
@@ -1,0 +1,219 @@
+#!/bin/bash
+# Copyright 2022 SUSE, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+error() {
+  echo $* >/dev/stderr
+}
+
+usage() {
+  cat << EOF
+usage: $0 LOGFILE <mandatory> [options]
+
+mandatory:
+  --branch NAME     Name of aquarist-labs/ceph.git branch.
+  --pr ID           Pull Request ID from aquarist-labs/ceph.git.
+  --sha STRING      SHA256 of tested commit from tested branch.
+
+  One of --branch or --pr must be specified, but never the two at the
+  same time.
+
+options:
+  --help|-h         This message
+  --user NAME       User generating this report (default: ${USER}).
+  --publish         Publish the result to the 's3gw-status' repository.
+
+example:
+  $ $0 s3gw-s3test-2022-06-03-205212-1ldv/s3gw-s3tests.log \\
+      --branch wip-foo \\
+      --sha 123aadsfsdf3244 \\
+      --user joao
+
+NOTE:
+
+  When using the '--publish' option, a clone of 's3gw-status.git' will be
+  required in the same directory from which this script is run. We recommend
+  configuring this repository prior to using this option to ensure properly
+  signed commits.
+
+EOF
+}
+
+res_errors=()
+res_fails=()
+res_okay=()
+resfile=
+branch=
+prid=
+sha=
+user=${USER}
+publish=false
+
+posargs=()
+while [[ $# -gt 0 ]]; do
+
+  case ${1} in
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --branch)
+      branch="${2}"
+      shift 1
+      ;;
+    --pr)
+      prid="${2}"
+      shift 1
+      ;;
+    --sha)
+      sha="${2}"
+      shift 1
+      ;;
+    --user)
+      user="${2}"
+      shift 1
+      ;;
+    --publish)
+      publish=true
+      ;;
+    *)
+      posargs=(${posargs[@]} ${1})
+      ;;
+  esac
+  shift 1
+
+done
+
+resfile=${posargs[0]}
+
+if [[ -z "${resfile}" ]]; then
+  error "error: results file not provided."
+  usage
+  exit 1
+
+elif [[ -z "${branch}" && -z "${prid}" ]]; then
+  error "error: neither --branch nor --pr specified."
+  exit 1
+
+elif [[ -n "${branch}" && -n "${prid}" ]]; then
+  error "error: both --branch and --pr specified."
+  exit 1
+
+elif [[ -z "${sha}" ]]; then
+  error "error: --sha not specified."
+  exit 1
+fi
+
+if $publish ; then
+
+  if [[ ! -d "s3gw-status.git" ]]; then
+    cat <<EOF
+error: 's3gw-status.git' repository not found in current directory.
+
+Please ensure a clone is present, and properly configured, before publishing
+results.
+
+E.g.,
+
+  $ git clone git@github.com:aquarist-labs/s3gw-status s3gw-status.git
+  $ cd s3gw-status.git
+  $ git config user.name "Joao Eduardo Luis"
+  $ git config user.email "joao@suse.com"
+  $ git config user.signingkey joao@suse.com
+
+EOF
+    exit 1
+  fi
+fi
+
+while IFS= read -r line ; do
+  [[ -z "${line}" ]] && break
+  [[ ! "${line}" =~ .*" ... ".* ]] && continue
+  read -r testname testres <<< \
+    $(echo "${line}" | sed -n 's/\(.*\) ... \(.*\)/\1 \2/p')
+
+  case ${testres} in
+    ok)
+      res_okay=(${res_okay[@]} ${testname})
+      ;;
+    ERROR)
+      res_errors=(${res_errors[@]} ${testname})
+      ;;
+    FAIL)
+      res_fails=(${res_fails[@]} ${testname})
+      ;;
+  esac
+
+done < "${resfile}"
+
+now=$(date -u +"%FT%TZ")
+outfn="s3gw-s3tests-${now}-${user}.json"
+cat >>${outfn} <<EOF
+{
+  "branch": "${branch}",
+  "pr": "${prid}",
+  "sha": "${sha}",
+  "date": "${now}",
+  "user": "${user}",
+  "results": {
+    "success": [
+EOF
+for ((i=0 ; i < ${#res_okay[@]} ; i++)); do
+  comma=","
+  [[ $((i+1)) -eq ${#res_okay[@]} ]] && comma=
+  cat >>${outfn} <<EOF
+      "${res_okay[$i]}"${comma}
+EOF
+done
+cat >>${outfn} <<EOF
+    ],
+    "failed": [
+EOF
+for ((i=0 ; i < ${#res_fails[@]} ; i++)); do
+  comma=","
+  [[ $((i+1)) -eq ${#res_fails[@]} ]] && comma=
+  cat >>${outfn} <<EOF
+      "${res_fails[$i]}"${comma}
+EOF
+done
+cat >>${outfn} <<EOF
+    ],
+    "errors": [
+EOF
+for ((i=0 ; i < ${#res_errors[@]} ; i++)); do
+  comma=","
+  [[ $((i+1)) -eq ${#res_errors[@]} ]] && comma=
+  cat >>${outfn} <<EOF
+      "${res_errors[$i]}"${comma}
+EOF
+done
+cat >>${outfn} <<EOF
+    ]
+  }
+}
+EOF
+
+echo "wrote report to ${outfn}"
+
+if $publish ; then
+  cp ${outfn} s3gw-status.git/results/s3tests/${outfn} || exit 1
+  pushd s3gw-status.git || exit 1
+  git remote update || exit 1
+  git pull origin main || exit 1
+  git checkout main || exit 1
+  git add results/${outfn} || exit 1
+  git commit -m "results/s3tests: report ${outfn}" -S -s || exit 1
+  git push origin main || exit 1
+fi
+

--- a/tests/s3gw-bench.sh
+++ b/tests/s3gw-bench.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# Copyright 2022 SUSE, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+gopath=${GOPATH:-${HOME}/go/bin}
+
+error() {
+  echo $* >/dev/stderr
+}
+
+usage() {
+  cat >/dev/stderr <<EOF
+usage: $0 HOST[:PORT] [options]
+
+options:
+  --large     Run a large test.
+  --medium    Run a medium test.
+  --small     Run a small test.
+EOF
+}
+
+if [[ ! -d "${gopath}" ]]; then
+  error "error: unable to find go binary path at '${gopath}'"
+  exit 1
+fi
+
+warpcmd="${gopath}/warp"
+if [[ ! -e "${warpcmd}" ]]; then
+  error "error: unable to find 'warp' at '${gopath}'"
+  error "consider installing with 'go install github.com/minio/warp@latest'"
+  exit 1
+fi
+
+duration="1m"
+objects=50
+test_type="small"
+
+pos_args=()
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --large)
+      duration="10m"
+      objects=6000
+      test_type="large"
+      ;;
+    --medium)
+      duration="5m"
+      objects=1000
+      test_type="medium"
+      ;;
+    --small)
+      duration="1m"
+      objects=50
+      test_type="small"
+      ;;
+    *)
+      pos=(${pos[@]} $1)
+      ;;
+  esac
+  shift 1
+done
+
+url="${pos[0]}"
+if [[ -z "${url}" ]]; then
+  usage
+  exit 1
+fi
+
+cat <<EOF
+Running ${test_type} test with
+  duration: ${duration}
+   objects: ${objects}
+EOF
+
+run_test() {
+
+  objsize="${1}"
+  if [[ -z "${objsize}" ]]; then
+    error "error: missing object size for test run"
+    exit 1
+  fi
+
+  testdate="$(date -u +%F[%H%M%S])"
+  testid="$(tr -dc a-z0-9 < /dev/urandom | head -c 4)"
+  testbucket="s3gw-bench-${testid}"
+  testout="s3gw-bench-${test_type}-${testdate}-${testid}-${objsize}.csv.zst"
+
+  ${warpcmd} mixed --host ${url} \
+    --access-key test --secret-key test \
+    --obj.size ${objsize} --objects ${objects} \
+    --duration ${duration} \
+    --noclear \
+    --bucket ${testbucket} \
+    --analyze.out ${testout}
+  return $?
+}
+
+run_test 1MiB || exit 1
+run_test 10MiB || exit 1
+# run_test 100MiB || exit 1

--- a/tests/s3gw-s3tests.sh
+++ b/tests/s3gw-s3tests.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Copyright 2022 SUSE, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+error() {
+  echo $* >/dev/stderr
+}
+
+usage() {
+  cat >/dev/stderr <<EOF
+usage: $0 HOST[:PORT]
+EOF
+}
+
+hostport=(${1//:/ })
+host=${hostport[0]}
+port=${hostport[1]:-7480}
+
+if [[ -z "${host}" || -z "${port}" ]]; then
+  usage
+  exit 1
+fi
+
+testdate="$(date -u +%F-%H%M%S)"
+testid="$(tr -dc a-z0-9 < /dev/urandom | head -c 4)"
+testdir="s3gw-s3test-${testdate}-${testid}"
+
+mkdir ${testdir} || exit 1
+pushd ${testdir} || exit 1
+
+cat > s3test.conf <<EOF
+[DEFAULT]
+host = ${host}
+port = ${port}
+is_secure = False
+ssl_verify = False
+
+[fixtures]
+bucket prefix = s3gwtest-{random}-
+
+[s3 main]
+display_name = M. Tester
+user_id = testid
+email = tester@ceph.com
+api_name = default
+access_key = test
+secret_key = test
+
+[s3 alt]
+display_name = john.doe
+email = john.doe@example.com
+user_id = testid
+access_key = test
+secret_key = test 
+
+[s3 tenant]
+display_name = testx$tenanteduser
+user_id = testid
+access_key = test 
+secret_key = test 
+email = tenanteduser@example.com
+
+[iam]
+email = s3@example.com
+user_id = testid
+access_key = test 
+secret_key = test 
+display_name = youruseridhere
+EOF
+
+git clone -b ceph-master https://github.com/ceph/s3-tests s3-tests.git || \
+  exit 1
+pushd s3-tests.git || exit 1
+
+python3 -m venv venv || exit 1
+source venv/bin/activate
+pip install -r requirements.txt || exit 1
+
+( S3TEST_CONF=../s3test.conf nosetests -v -s \
+  -a '!fails_on_rgw,!lifecycle_expiration,!fails_strict_rfc2616' \
+  s3tests_boto3.functional |& tee ../s3gw-s3tests.log ) || exit 1
+
+exit 0

--- a/tests/s3gw-smoke-test.sh
+++ b/tests/s3gw-smoke-test.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Copyright 2022 SUSE, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+testpath=$(mktemp -d s3gw.XXXX --tmpdir=/tmp)
+s3cfg=${testpath}/s3cfg
+url="${1}"
+
+usage() {
+  cat << EOF
+usage: $0 ADDRESS[:PORT[/LOCATION]]
+EOF
+}
+
+s3() {
+  s3cmd -c ${s3cfg} $*
+  return $?
+}
+
+[[ -z "${url}" ]] && usage && exit 1
+
+cat > ${s3cfg} << EOF
+[default]
+access_key = test
+secret_key = test
+host_base = ${url}/
+host_bucket = ${url}/%(bucket)
+signurl_use_https = False
+use_https = False
+signature_v2 = True
+signurl_use_https = False
+EOF
+
+pushd ${testpath}
+
+# Please note: rgw will refuse bucket names with upper case letters.
+# This is due to amazon s3's bucket naming restrictions.
+# See:
+# https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+#
+bucket="s3gw-test-$(tr -dc a-z0-9 < /dev/urandom | head -c 4)"
+
+s3 ls s3:// || exit 1
+s3 mb s3://${bucket} || exit 1
+s3 ls s3://${bucket} || exit 1
+s3 ls s3://${bucket}-dne && exit 1
+
+dd if=/dev/random bs=1k count=1k of=obj1.bin || exit 1
+
+s3 put obj1.bin s3://${bucket}/ || exit 1
+s3 put obj1.bin s3://${bucket}/obj1.bin || exit 1
+s3 put obj1.bin s3://${bucket}/obj1.bin.2 || exit 1
+s3 put obj1.bin s3://${bucket}/my/obj1.bin || exit 1
+s3 get s3://${bucket}/obj1.bin obj1.bin.local || exit 1
+orig_md5=$(md5sum -b obj1.bin | cut -f1 -d' ')
+down_md5=$(md5sum -b obj1.bin.local | cut -f1 -d' ')
+
+[[ "${orig_md5}" == "${down_md5}" ]] || exit 1
+
+s3 get s3://${bucket}/dne.bin && exit 1
+
+must_have=("obj1.bin" "obj1.bin.2" "my/obj1.bin")
+ifs_old=$IFS
+IFS=$'\n'
+lst=($(s3 ls s3://${bucket}))
+
+[[ ${#lst[@]} -eq 3 ]] || exit 1
+for what in ${must_have[@]} ; do
+  found=false
+  for e in ${lst[@]}; do
+    r=$(echo $e | grep "s3://${bucket}/${what}$")
+    [[ -n "${r}" ]] && found=true && break
+  done
+  $found || exit 1
+done
+
+exit 0

--- a/tests/s3gw-smoke-test.sh
+++ b/tests/s3gw-smoke-test.sh
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -x
+
 testpath=$(mktemp -d s3gw.XXXX --tmpdir=/tmp)
 s3cfg=${testpath}/s3cfg
 url="${1}"


### PR DESCRIPTION
These are to be run against a file based backend. As they stand, the access key and secret key are not configurable to support dbstore and the likes.

This is meant as something to be expanded on, instead of implementing a comprehensive solution right now.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>