### PR TITLE
tests/s3tests: fix report publishing

### DIFF
--- a/tests/create-s3tests-report.sh
+++ b/tests/create-s3tests-report.sh
@@ -212,7 +212,7 @@ if $publish ; then
   git remote update || exit 1
   git pull origin main || exit 1
   git checkout main || exit 1
-  git add results/${outfn} || exit 1
+  git add results/s3tests/${outfn} || exit 1
   git commit -m "results/s3tests: report ${outfn}" -S -s || exit 1
   git push origin main || exit 1
 fi


### PR DESCRIPTION
After changing where we keep the s3tests reports in the s3gw-status
repository, there was a little path that was not properly changed.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>