### PR TITLE
build: use system boost

### DIFF
--- a/build/Dockerfile.build-radosgw
+++ b/build/Dockerfile.build-radosgw
@@ -18,6 +18,22 @@ RUN zypper -n install --no-recommends \
   python3-PrettyTable python3-PyYAML python3-Sphinx python3-devel \
   python3-setuptools rdma-core-devel re2-devel snappy-devel sqlite-devel \
   sudo systemd-rpm-macros valgrind-devel which xfsprogs-devel xmlstarlet
+# Use prebuilt boost
+RUN zypper -n install --no-recommends \
+      libboost_atomic1_79_0-devel \
+      libboost_context1_79_0-devel \
+      libboost_coroutine1_79_0-devel \
+      libboost_filesystem1_79_0-devel \
+      libboost_iostreams1_79_0-devel \
+      libboost_program_options1_79_0-devel \
+      libboost_python-py3-1_79_0-devel \
+      libboost_random1_79_0-devel \
+      libboost_regex1_79_0-devel \
+      libboost_system1_79_0-devel \
+      libboost_thread1_79_0-devel \
+      librabbitmq-devel \
+      librdkafka-devel \
+ && zypper clean --all
 
 COPY build-radosgw.sh /usr/bin/build-radosgw.sh
 

--- a/build/build-radosgw.sh
+++ b/build/build-radosgw.sh
@@ -17,6 +17,7 @@ CEPH_CMAKE_ARGS="-DWITH_RADOSGW_SELECT_PARQUET=OFF -DWITH_RADOSGW_MOTR=OFF ${CEP
 CEPH_CMAKE_ARGS="-DWITH_RADOSGW_DBSTORE=ON -DWITH_RADOSGW_LUA_PACKAGES=OFF ${CEPH_CMAKE_ARGS}"
 CEPH_CMAKE_ARGS="-DWITH_MANPAGE=OFF -DWITH_OPENLDAP=OFF -DWITH_LTTNG=OFF ${CEPH_CMAKE_ARGS}"
 CEPH_CMAKE_ARGS="-DWITH_RDMA=OFF ${CEPH_CMAKE_ARGS}"
+CEPH_CMAKE_ARGS="-DWITH_SYSTEM_BOOST=ON ${CEPH_CMAKE_ARGS}"
 NPROC=${NPROC:-$(nproc --ignore=2)}
 
 build_radosgw() {
@@ -33,6 +34,9 @@ build_radosgw() {
   fi
 
   cd ${CEPH_DIR}
+
+  # This is necessary since git v2.35.2 because of CVE-2022-24765
+  git config --global --add safe.directory "${CEPH_DIR}"
 
   ./install-deps.sh || true
 


### PR DESCRIPTION
- Use system boost to build against.
  This reduces the compile time a bit.
- Configure git safe directory in the build container.
  Since git v2.35.2, this is necessary e.g. for `git submodule update`

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>