### PR TITLE
radosgw-container: install system boost libraries

### DIFF
--- a/build/Dockerfile.build-container
+++ b/build/Dockerfile.build-container
@@ -9,12 +9,34 @@ RUN zypper -n install libblkid1 \
   libtcmalloc4 \
   libfmt8 \
   liboath0 \
-  libicu71
+  libicu71 \
+  libboost_atomic1_79_0 \
+  libboost_chrono1_79_0 \
+  libboost_context1_79_0 \
+  libboost_coroutine1_79_0 \
+  libboost_date_time1_79_0 \
+  libboost_filesystem1_79_0 \
+  libboost_iostreams1_79_0 \
+  libboost_program_options1_79_0 \
+  libboost_random1_79_0 \
+  libboost_regex1_79_0 \
+  libboost_serialization1_79_0 \
+  libboost_system1_79_0 \
+  libboost_thread1_79_0 \
+ && zypper clean --all
 
 RUN mkdir -p /data
 
 COPY ./bin/radosgw /usr/bin/radosgw
-COPY ./lib/*.so* /usr/lib64/
+COPY [ "./lib/libradosgw.so", \
+       "./lib/libradosgw.so.2", \
+       "./lib/libradosgw.so.2.0.0", \
+       "./lib/librados.so", \
+       "./lib/librados.so.2", \
+       "./lib/librados.so.2.0.0", \
+       "./lib/libceph-common.so", \
+       "./lib/libceph-common.so.2", \
+       "/usr/lib64/" ]
 
 EXPOSE 7480
 


### PR DESCRIPTION
- Install system boost libraries in the s3gw container
- Copy shared object files explicitly

Since we are building against system boost libraries, this is necessary
to run the radosgw binary.
Copying shared object files explicitly avoids accidentally copying
additional files, thereby increasing image size unnecessarily.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>