### PR TITLE
Install libsqliteorm from OBS repository.

### DIFF
--- a/build/Dockerfile.build-radosgw
+++ b/build/Dockerfile.build-radosgw
@@ -1,5 +1,10 @@
 FROM opensuse/tumbleweed
 
+# Add OBS repository for libsqliteorm
+RUN zypper ar https://download.opensuse.org/repositories/home:/jluis/openSUSE_Tumbleweed/ sqliteorm
+RUN zypper --gpg-auto-import-keys ref
+RUN zypper -n install libsqliteorm
+
 RUN zypper -n install bash make git ccache cmake ninja jq binutils
 # hard-coded in ceph's `install-deps.sh`
 RUN zypper -n install --no-recommends systemd-rpm-macros rpm-build


### PR DESCRIPTION
After merging [this PR](https://github.com/aquarist-labs/ceph/pull/12) the simplefile store in radosgw needs `libsqliteorm` when building.

This adds the OBS repository containing libsqliteorm and installs it.

Nothing else is needed, as `sqlite_orm` is a header only library.

Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>