### PR TITLE
Stress testing s3gw with fio

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -74,4 +74,91 @@ Each time `wrap` is run, a file will be created containing the results of
 the benchmark. This file can later on be used to compare results between runs.
 For more information, please check `warp`'s help.
 
+## stress testing
 
+For the purpose of stress testing `s3gw`, you can rely on
+[fio](https://github.com/axboe/fio).
+The tool is equipped with an http client that can also act as an
+`S3` client.  
+You can therefore use the tool to issue concurrent and/or serial operations against
+`s3gw`.
+For a basic stress testing activity you should normally want to shot a series
+of `PUT`(s), `GET`(s) and `DELETE`(s).  
+Such workload can be modeled with a fio *jobfile*.  
+For example, you can customize the following *jobfile* and tuning it to realize
+the test you wish to perform.
+
+```ini
+[global]
+ioengine=http
+filename=/foo/obj
+http_verbose=0
+https=off
+http_mode=s3
+http_s3_key=test
+http_s3_keyid=test
+http_host=localhost:7480
+
+[s3-write]
+numjobs=4
+rw=write
+size=16m
+bs=16m
+
+[s3-read]
+numjobs=4
+rw=read
+size=16m
+bs=16m
+
+[s3-trim]
+stonewall
+numjobs=1
+rw=trim
+size=16m
+bs=16m
+```
+
+Once you have created your *jobfile*: `s3gw.fio` you can simply launch the workload with:
+
+```shell
+$ fio s3gw.fio
+Starting 9 processes
+
+...
+```
+
+This *jobfile* connects to an S3 gateway listening on `localhost:7480`
+and operates on a object `obj`
+which resides inside an existing `foo` bucket.  
+This example launches 3 types of jobs: `s3-write` (PUT), `s3-read`
+(GET) and `s3-trim` (DELETE);
+the actual operation verb is defined by `rw` property.  
+The actual number of processes performing the same operation is controlled by
+`numjobs` property.  
+`global` section is inherited from all defined jobs.  
+For this specific example the I/O activity is defined by: `size=16m bs=16m`
+meaning that, a 16mb file will be `write`, `read` and `trim` with a single
+16mb weighting I/O operation.  
+As result of this, supposing that no `trim` job has been defined, you would
+find in the bucket a 16mb object:
+
+```shell
+$ s3cmd ls s3://foo
+2022-07-19 13:14     16777216  s3://foo/obj_0_16777216
+```
+
+Modifying the `bs` property to the value of `4m` you are diminishing
+the weight of a single I/O operation over an overall `16m` size.  
+As result of this, you would find 4 (16mb/4mb) single objects in the bucket:
+
+```shell
+$ s3cmd ls s3://foo
+2022-07-19 13:21      4194304  s3://foo/obj_0_4194304
+2022-07-19 13:21      4194304  s3://foo/obj_12582912_4194304
+2022-07-19 13:21      4194304  s3://foo/obj_4194304_4194304
+2022-07-19 13:21      4194304  s3://foo/obj_8388608_4194304
+```
+
+To build more complex`fio` workloads, refer to its 
+[documentation](https://fio.readthedocs.io/en/latest/index.html).


### PR DESCRIPTION
Added documentation in docs/testing.md for building a stress test scenario with fio against s3gw.
If you have other ideas or desiderata you would like to implement, please elaborate.

Fixes: https://github.com/aquarist-labs/s3gw-core/issues/93
Signed-off-by: Giuseppe Baccini <giuseppe.baccini@suse.com>