### PR TITLE
container: implement stopsignal handling

### DIFF
--- a/build-ui/Dockerfile.app
+++ b/build-ui/Dockerfile.app
@@ -4,11 +4,12 @@ RUN apk add gettext
 RUN npm install -g http-server
 RUN echo -e "#!/bin/sh\n" \
   "envsubst < /app/assets/rgw_service.config.json.sample > /app/assets/rgw_service.config.json\n" \
-  "http-server /app/\n" > /usr/bin/entrypoint.sh
+  "exec http-server /app/\n" > /usr/bin/entrypoint.sh
 RUN chmod +x /usr/bin/entrypoint.sh
 
 WORKDIR /app
 COPY ./ .
 
 EXPOSE 8080
+STOPSIGNAL SIGINT
 ENTRYPOINT [ "/usr/bin/entrypoint.sh" ]


### PR DESCRIPTION
Implement correct stopsignal handling for the container image.
The http-server process responds quickly and well defined to a SIGINT
with a shutdown. This is much better than letting the container runtime
clean up the process and all resources after timing out when terminating
the container with SIGTERM (the default).
This allows for quicker shutdowns aiding any HA setups with pacemaker
and generally being much nicer to work with for operators.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>