### PR TITLE
ci: inherit secrets from calling workflow

### DIFF
--- a/.github/workflows/build-environment.yaml
+++ b/.github/workflows/build-environment.yaml
@@ -17,16 +17,6 @@ on:
         required: false
         default: "main"
         type: string
-      dockerhub_username:
-        description: "A username to use for push to dockerhub"
-        required: true
-        default: ${{ secrets.DOCKERHUB_USERNAME }}
-        type: string
-      dockerhub_token:
-        description: "A token to use for push to dockerhub"
-        required: true
-        default: ${{ secrets.DOCKERHUB_TOKEN }}
-        type: string
 
 jobs:
   build:
@@ -47,8 +37,8 @@ jobs:
       - name: Dockerhub Login
         uses: docker/login-action@v1
         with:
-          username: ${{ inputs.dockerhub_username }}
-          password: ${{ inputs.dockerhub_token }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set Container Image Tag
         id: tag
@@ -63,6 +53,6 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: ${{ inputs.dockerhub_username }}/buildenv-radosgw:${{ steps.tag.outputs.tag }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/buildenv-radosgw:${{ steps.tag.outputs.tag }}
           file: 'build/Dockerfile.build-radosgw'
           context: 'build'


### PR DESCRIPTION
Inherit secrets from calling workflow. Accepting them as normal parameters does not work, but it can be assumes that the caller will pass the secrets either explicitly or via the inherit mechanism.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>