### PR TITLE
buildenv: let zypper resolve package dependencies

### DIFF
--- a/build/Dockerfile.build-radosgw
+++ b/build/Dockerfile.build-radosgw
@@ -1,30 +1,35 @@
 FROM opensuse/tumbleweed
 
 # Add OBS repository for libsqliteorm
-RUN zypper ar https://download.opensuse.org/repositories/home:/jluis/openSUSE_Tumbleweed/ sqliteorm
-RUN zypper --gpg-auto-import-keys ref
-RUN zypper -n install libsqliteorm
-
-RUN zypper -n install bash make git ccache cmake ninja jq binutils which
-# hard-coded in ceph's `install-deps.sh`
-RUN zypper -n install --no-recommends systemd-rpm-macros rpm-build
-# obtained by running `install-deps.sh` 2022-05-04
+RUN zypper ar \
+  https://download.opensuse.org/repositories/home:/jluis/openSUSE_Tumbleweed/ \
+  sqliteorm \
+ && zypper --gpg-auto-import-keys ref
 RUN zypper -n install --no-recommends \
-  babeltrace-devel 'cmake>3.5' cryptsetup-devel cunit-devel fdupes \
-  'fmt-devel>=6.2.1' fuse-devel gcc-c++ golang-github-prometheus-prometheus \
-  gperf 'gperftools-devel>=2.4' keyutils-devel libaio-devel \
-  'libblkid-devel>=2.17' libbz2-devel libcap-ng-devel libcurl-devel \
-  libexpat-devel libicu-devel 'liblz4-devel>=1.7' libnl3-devel liboath-devel \
-  libopenssl-devel libpmem-devel libpmemobj-devel 'libthrift-devel>=0.13.0' \
-  libtool libxml2-devel lttng-ust-devel lua-devel lua54-luarocks make \
-  memory-constraints mozilla-nss-devel nasm ncurses-devel net-tools ninja \
-  openldap2-devel patch perl pkgconfig 'pkgconfig(libudev)' \
-  'pkgconfig(systemd)' 'pkgconfig(udev)' procps python3 python3-Cython \
-  python3-PrettyTable python3-PyYAML python3-Sphinx python3-devel \
-  python3-setuptools rdma-core-devel re2-devel snappy-devel sqlite-devel \
-  sudo systemd-rpm-macros valgrind-devel xfsprogs-devel xmlstarlet
-# Use prebuilt boost
-RUN zypper -n install --no-recommends \
+      'cmake>3.5' \
+      'fmt-devel>=6.2.1' \
+      'gperftools-devel>=2.4' \
+      'libblkid-devel>=2.17' \
+      'liblz4-devel>=1.7' \
+      'libthrift-devel>=0.13.0' \
+      'pkgconfig(libudev)' \
+      'pkgconfig(systemd)' \
+      'pkgconfig(udev)' \
+      babeltrace-devel \
+      bash \
+      binutils \
+      ccache \
+      cmake \
+      cryptsetup-devel \
+      cunit-devel \
+      fdupes \
+      fuse-devel \
+      gcc-c++ \
+      git \
+      gperf \
+      jq \
+      keyutils-devel \
+      libaio-devel \
       libboost_atomic1_80_0-devel \
       libboost_context1_80_0-devel \
       libboost_coroutine1_80_0-devel \
@@ -36,8 +41,55 @@ RUN zypper -n install --no-recommends \
       libboost_regex1_80_0-devel \
       libboost_system1_80_0-devel \
       libboost_thread1_80_0-devel \
+      libbz2-devel \
+      libcap-ng-devel \
+      libcurl-devel \
+      libexpat-devel \
+      libicu-devel \
+      libnl3-devel \
+      liboath-devel \
+      libopenssl-devel \
+      libpmem-devel \
+      libpmemobj-devel \
       librabbitmq-devel \
       librdkafka-devel \
+      libsqliteorm \
+      libtool \
+      libxml2-devel \
+      lttng-ust-devel \
+      lua-devel \
+      lua54-luarocks \
+      make \
+      make \
+      memory-constraints \
+      mozilla-nss-devel \
+      nasm \
+      ncurses-devel \
+      net-tools \
+      ninja \
+      ninja \
+      openldap2-devel \
+      patch \
+      perl \
+      pkgconfig \
+      procps \
+      python3 \
+      python3-Cython \
+      python3-PrettyTable \
+      python3-PyYAML \
+      python3-Sphinx \
+      python3-devel \
+      python3-setuptools \
+      rdma-core-devel \
+      re2-devel \
+      rpm-build \
+      snappy-devel \
+      sqlite-devel \
+      systemd-rpm-macros \
+      systemd-rpm-macros \
+      valgrind-devel \
+      xfsprogs-devel \
+      xmlstarlet \
  && zypper clean --all
 
 COPY build-radosgw.sh /usr/bin/build-radosgw.sh


### PR DESCRIPTION
Consolidate package installation into a single call to zypper. This helps zypper by giving it a better overview of what is going to be installed and thus help avoid packaging conflicts.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>