### PR TITLE
build tools: fix build process

### DIFF
--- a/build/Dockerfile.build-radosgw
+++ b/build/Dockerfile.build-radosgw
@@ -16,20 +16,23 @@ RUN zypper -n install --no-recommends \
       'pkgconfig(systemd)' \
       'pkgconfig(udev)' \
       babeltrace-devel \
-      bash \
       binutils \
       ccache \
       cmake \
+      cpp11 \
       cryptsetup-devel \
       cunit-devel \
       fdupes \
       fuse-devel \
       gcc-c++ \
+      gcc11 \
+      gcc11-c++ \
       git \
       gperf \
       jq \
       keyutils-devel \
       libaio-devel \
+      libasan6 \
       libboost_atomic1_80_0-devel \
       libboost_context1_80_0-devel \
       libboost_coroutine1_80_0-devel \
@@ -54,12 +57,13 @@ RUN zypper -n install --no-recommends \
       librabbitmq-devel \
       librdkafka-devel \
       libsqliteorm \
+      libstdc++6-devel-gcc11 \
       libtool \
+      libtsan0 \
       libxml2-devel \
       lttng-ust-devel \
       lua-devel \
       lua54-luarocks \
-      make \
       make \
       memory-constraints \
       mozilla-nss-devel \

--- a/build/build-radosgw.sh
+++ b/build/build-radosgw.sh
@@ -51,9 +51,8 @@ build_radosgw() {
   cd ${CEPH_DIR}
 
   # This is necessary since git v2.35.2 because of CVE-2022-24765
-  git config --global --add safe.directory "${CEPH_DIR}"
-
-  ./install-deps.sh || true
+  # but we have to continue in case CEPH_DIR is not a git repo
+  git config --global --add safe.directory "${CEPH_DIR}" || true
 
   if [ -d "build" ]; then
       cd build/


### PR DESCRIPTION
- Fix build process for when ceph sources are not located in a top level git repo (e.g. when ceph sources are located in a subrepo).

- Remove golang-github-prometheus as build dependency. This is just not necessary.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>