### PR TITLE
test/smoke: Fix versioning tests after multipart PR fixed etags.

### DIFF
--- a/tests/s3gw-versioning-smoke-tests.py
+++ b/tests/s3gw-versioning-smoke-tests.py
@@ -130,13 +130,25 @@ class VersioningSmokeTests(unittest.TestCase):
             self.assertEqual(object_name, version['Key'])
             self.assertEqual('STANDARD', version['StorageClass'])
             self.assertEqual({'DisplayName': 'M. Tester', 'ID': 'testid'}, version['Owner'])
-            self.assertEqual(etag, version['ETag'])
             self.assertNotEqual('null', version['VersionId'])
             if (version['IsLatest']):
                 num_latest += 1
                 last_version_id = version['VersionId']
+                self.assertEqual(etag, version['ETag'])
             else:
                 previous_version_id = version['VersionId']
+
+        # check that all etags differ
+        for version in response['Versions']:
+            etag = version['ETag']
+            version_id = version['VersionId']
+            for version2 in response['Versions']:
+                version_id2 = version2['VersionId']
+                if (version_id2 != version_id):
+                    etag2 = version2['ETag']
+                    self.assertNotEqual(etag, etag2)
+
+
         self.assertEqual(1, num_latest)
         self.assertNotEqual('', last_version_id)
         self.assertNotEqual('', previous_version_id)
@@ -175,7 +187,6 @@ class VersioningSmokeTests(unittest.TestCase):
             self.assertEqual(object_name, version['Key'])
             self.assertEqual('STANDARD', version['StorageClass'])
             self.assertEqual({'DisplayName': 'M. Tester', 'ID': 'testid'}, version['Owner'])
-            self.assertEqual(etag, version['ETag'])
             self.assertNotEqual('null', version['VersionId'])
             self.assertFalse(version['IsLatest'])
 


### PR DESCRIPTION
After merging https://github.com/aquarist-labs/ceph/pull/40 versioning tests need to be fixed because now etags for all versions differ from the main object.

Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR.
