### PR TITLE
fix build_radosgw CCACHE environment variable

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -134,7 +134,7 @@ build_radosgw() {
   fi
 
   podman run -it --replace --name s3gw-builder \
-    -e S3GW_CCACHE_DIR=/srv/ccache \
+    -e SFS_CCACHE_DIR=/srv/ccache \
     -e WITH_TESTS=${with_tests} \
     ${volumes[@]} \
     ${build_image}


### PR DESCRIPTION
build-radosgw.sh[0] in the build container expects SFS_CCACHE_DIR not S3GW_CCACHE_DIR

[0] https://github.com/aquarist-labs/ceph/blob/s3gw/qa/rgw/store/sfs/build-radosgw.sh

Signed-off-by: Marcel Lauhoff <marcel.lauhoff@suse.com>
