### PR TITLE
build: add missing 'libcap-devel' to radosgw build

### DIFF
--- a/build/Dockerfile.build-radosgw
+++ b/build/Dockerfile.build-radosgw
@@ -45,6 +45,7 @@ RUN zypper -n install --no-recommends \
       libboost_system1_80_0-devel \
       libboost_thread1_80_0-devel \
       libbz2-devel \
+      libcap-devel \
       libcap-ng-devel \
       libcurl-devel \
       libexpat-devel \


### PR DESCRIPTION
Signed-off-by: Joao Eduardo Luis \<joao@suse.com>