### PR TITLE
build: drop libradosgw libs from s3gw container

### DIFF
--- a/build/Dockerfile.build-container
+++ b/build/Dockerfile.build-container
@@ -39,9 +39,7 @@ ENV LD_LIBRARY_PATH /radosgw:$LD_LIBRARY_PATH
 RUN mkdir -p /data
 
 COPY ./bin/radosgw /radosgw/
-COPY [ "./lib/libradosgw.so", \
-       "./lib/libradosgw.so.2", \
-       "./lib/libradosgw.so.2.0.0", \
+COPY [ \
        "./lib/librados.so", \
        "./lib/librados.so.2", \
        "./lib/librados.so.2.0.0", \


### PR DESCRIPTION
We are no longer building libradosgw.so, and it seems the radosgw binary is statically linking librgw_a.a instead.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>